### PR TITLE
feat: v6.4.18.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG for Shopware PWA
 ===================
 
+### 0.3.4
+
+**Changed**
+
+* Changed deprecated routes scope annotation from `@RouteScope(...)` to new `@Route(...)` format.
+
+
 ### 0.3.3
 
 **Fixed**

--- a/src/Pwa/Controller/PageController.php
+++ b/src/Pwa/Controller/PageController.php
@@ -3,7 +3,6 @@
 namespace SwagShopwarePwa\Pwa\Controller;
 
 use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use SwagShopwarePwa\Pwa\PageLoader\Context\PageLoaderContext;
 use SwagShopwarePwa\Pwa\PageLoader\Context\PageLoaderContextBuilderInterface;
@@ -16,7 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use OpenApi\Annotations as OA;
 
 /**
- * @RouteScope(scopes={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"}})
  */
 class PageController extends AbstractController
 {

--- a/src/Shopware/Controller/Api/PwaController.php
+++ b/src/Shopware/Controller/Api/PwaController.php
@@ -2,7 +2,6 @@
 
 namespace SwagShopwarePwa\Shopware\Controller\Api;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use SwagShopwarePwa\Pwa\Bundle\AssetService;
 use SwagShopwarePwa\Pwa\Bundle\ConfigurationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -12,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
+ * @Route(defaults={"_routeScope"={"api"}})
  */
 class PwaController extends AbstractController
 {


### PR DESCRIPTION
provides compatibility for latest v6.4 version of Shopware Platform.

- replaces annotation to the new one, because the `@RouteScope` caused 500 error (including deprecation message)

TODO:
- remove not necessary imports of modules in plugin scope in php classes
- ask the core if 500 error (on dev and prod mode) is intended in case of deprecation message