### PR TITLE
fix: adjust setting name of command

### DIFF
--- a/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
+++ b/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
@@ -4,23 +4,18 @@ namespace SwagShopwarePwa\Pwa\Bundle\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use SwagShopwarePwa\Pwa\Bundle\AssetService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'pwa:dump-plugins', description: 'Dump PWA plugin configurations and assets')]
 class DumpPluginConfigurationCommand extends Command
 {
-    protected static $defaultName = 'pwa:dump-plugins';
-
     public function __construct(
         private readonly AssetService $assetService
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Dump PWA plugin configurations and assets');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
Right now there is a warning because the name of the command is not set.
```
[WARNING] Some commands could not be registered:

In Application.php line 533:

  [Symfony\Component\Console\Exception\LogicException]
  The command defined in "SwagShopwarePwa\Pwa\Bundle\Command\DumpPluginConfig
  urationCommand" cannot have an empty name.
```